### PR TITLE
annex管理とgit管理を分けて書き戻すよう修正

### DIFF
--- a/PACKAGE/EX-WORKFLOW/enter_metadata.ipynb
+++ b/PACKAGE/EX-WORKFLOW/enter_metadata.ipynb
@@ -150,15 +150,11 @@
     "import papermill as pm\n",
     "\n",
     "%cd ~/\n",
+    "save_path = ['/home/jovyan/meta_data.json', '/home/jovyan/EX-WORKFLOW/enter_metadata.ipynb']\n",
     "pm.execute_notebook(\n",
     "    'EX-WORKFLOW/util/base_datalad_save_push.ipynb',\n",
     "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = 'メタデータ登録', IS_RECURSIVE = False, TO_GIT = True, PATH = '/home/jovyan/meta_data.json')\n",
-    ")\n",
-    "pm.execute_notebook(\n",
-    "    'EX-WORKFLOW/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = 'メタデータ登録', IS_RECURSIVE = False, TO_GIT = True, PATH = '/home/jovyan/EX-WORKFLOW/enter_metadata.ipynb')\n",
+    "    parameters = dict(SAVE_MESSAGE = 'メタデータ登録', IS_RECURSIVE = False, TO_GIT = True, PATH = save_path)\n",
     ")"
    ]
   }

--- a/PACKAGE/EX-WORKFLOW/finish.ipynb
+++ b/PACKAGE/EX-WORKFLOW/finish.ipynb
@@ -95,14 +95,18 @@
     "# Git管理のパスのリストを作成する\n",
     "%cd ~/\n",
     "files = os.listdir()\n",
-    "# ディレクトリ一覧からinput_dataとoutput_dataのディレクトリを排除する\n",
+    "# ディレクトリ一覧からGit-annex管理するディレクトリ(input_dataとoutput_data)を排除する\n",
     "dirs = [f for f in files if os.path.isdir(f)]\n",
     "dirs.remove('input_data')\n",
     "dirs.remove('output_data')\n",
     "# HOME直下のファイルを取得\n",
     "files = [f for f in files if os.path.isfile(f)]\n",
+    "# Git管理するパスの配列を作成する\n",
     "files.extend(dirs)\n",
-    "save_path = files"
+    "save_path = files\n",
+    "\n",
+    "# Git-annex管理するパスの配列を作成する\n",
+    "annexed_save_path = ['input_data', 'output_data']"
    ]
   },
   {
@@ -114,7 +118,6 @@
     "import papermill as pm\n",
     "\n",
     "%cd ~/\n",
-    "annexed_save_path = ['input_data', 'output_data']\n",
     "# Git-annex管理ファイルを保存\n",
     "pm.execute_notebook(\n",
     "    'EX-WORKFLOW/util/base_datalad_save_push.ipynb',\n",

--- a/PACKAGE/EX-WORKFLOW/finish.ipynb
+++ b/PACKAGE/EX-WORKFLOW/finish.ipynb
@@ -89,13 +89,43 @@
    },
    "outputs": [],
    "source": [
+    "import os\n",
+    "import glob\n",
+    "\n",
+    "# Git管理のパスのリストを作成する\n",
+    "%cd ~/\n",
+    "files = os.listdir()\n",
+    "# ディレクトリ一覧からinput_dataとoutput_dataのディレクトリを排除する\n",
+    "dirs = [f for f in files if os.path.isdir(f)]\n",
+    "dirs.remove('input_data')\n",
+    "dirs.remove('output_data')\n",
+    "# HOME直下のファイルを取得\n",
+    "files = [f for f in files if os.path.isfile(f)]\n",
+    "files.extend(dirs)\n",
+    "save_path = files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import papermill as pm\n",
     "\n",
     "%cd ~/\n",
+    "annexed_save_path = ['input_data', 'output_data']\n",
+    "# Git-annex管理ファイルを保存\n",
     "pm.execute_notebook(\n",
     "    'EX-WORKFLOW/util/base_datalad_save_push.ipynb',\n",
     "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = '実験終了')\n",
+    "    parameters = dict(SAVE_MESSAGE = '実験終了', PATH = annexed_save_path, IS_RECURSIVE = False)\n",
+    ")\n",
+    "# Git管理ファイルを保存\n",
+    "pm.execute_notebook(\n",
+    "    'EX-WORKFLOW/util/base_datalad_save_push.ipynb',\n",
+    "    '/home/jovyan/.local/push_log.ipynb',\n",
+    "    parameters = dict(SAVE_MESSAGE = '実験終了', TO_GIT = True, PATH = save_path, IS_RECURSIVE = False)\n",
     ")"
    ]
   }

--- a/PACKAGE/EX-WORKFLOW/prepare_input_data.ipynb
+++ b/PACKAGE/EX-WORKFLOW/prepare_input_data.ipynb
@@ -97,10 +97,11 @@
     "import papermill as pm\n",
     "\n",
     "%cd ~/\n",
+    "save_path = [ '/home/jovyan/input_data/'+input_repo_title, '/home/jovyan/.gitmodules']\n",
     "pm.execute_notebook(\n",
     "    'EX-WORKFLOW/util/base_datalad_save_push.ipynb',\n",
     "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = '入力データの準備', IS_RECURSIVE = False)\n",
+    "    parameters = dict(SAVE_MESSAGE = '入力データの準備', PATH = save_path, IS_RECURSIVE = False)\n",
     ")"
    ]
   }

--- a/PACKAGE/EX-WORKFLOW/save.ipynb
+++ b/PACKAGE/EX-WORKFLOW/save.ipynb
@@ -84,10 +84,18 @@
     "import papermill as pm\n",
     "\n",
     "%cd ~/\n",
+    "# 入出力データをGit-annex管理で保存する\n",
+    "annexed_save_path = ['/home/jovyan/input_data', '/home/jovyan/output_data']\n",
     "pm.execute_notebook(\n",
     "    'EX-WORKFLOW/util/base_datalad_save_push.ipynb',\n",
     "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = message)\n",
+    "    parameters = dict(SAVE_MESSAGE = message, PATH = annexed_save_path, IS_RECURSIVE = False)\n",
+    ")\n",
+    "# 実験ソースコードをGit管理で保存する\n",
+    "pm.execute_notebook(\n",
+    "    'EX-WORKFLOW/util/base_datalad_save_push.ipynb',\n",
+    "    '/home/jovyan/.local/push_log.ipynb',\n",
+    "    parameters = dict(SAVE_MESSAGE = message, PATH = '/home/jovyan/source', TO_GIT = True, IS_RECURSIVE = False)\n",
     ")"
    ]
   }


### PR DESCRIPTION
以下、修正点です。
・git管理とgit-annex管理を分けてデータガバナンス機能に書き戻す
・複数のファイルを書き戻す際には、ファイルパスの配列をdatalad_save_push.ipynbに渡す
・ファイルパスの配列を作成する処理の説明を追加（finish.ipynb）
・Git管理とGit-annex管理のファイルパスの作成処理を1つのセルに整理（finish.ipynb）
ご確認よろしくお願いします。