### PR TITLE
実行済マークをワークフロー図に反映

### DIFF
--- a/FLOW/util/base_required_first_time.ipynb
+++ b/FLOW/util/base_required_first_time.ipynb
@@ -123,11 +123,38 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### - 1.4 ワークフロー図を更新する"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cd ~/WORKFLOW/images\n",
+    "\n",
+    "find = '\"base_required_first_time\"[fontsize = 14];'\n",
+    "replace = '\"base_required_first_time\"[numbered = 済, fontsize = 14];'\n",
+    "path = 'notebooks.diag'\n",
+    "\n",
+    "with open(path, 'r') as f:\n",
+    "    s = f.read()\n",
+    "\n",
+    "with open(path, 'w') as f:\n",
+    "    s = s.replace(find, replace)\n",
+    "    f.write(s)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "hidden": true
    },
    "source": [
-    "### - 1.4 画面遷移前にNotebookを保存する"
+    "### - 1.5 画面遷移前にNotebookを保存する"
    ]
   },
   {

--- a/FLOW/util/scripts/nb_utils.py
+++ b/FLOW/util/scripts/nb_utils.py
@@ -12,8 +12,8 @@ from itertools import chain, zip_longest
 from jinja2 import Template
 from datetime import datetime
 
-title_font_size = 20
-item_font_size = 17
+title_font_size = 12
+item_font_size = 9
 head_margin = 3
 text_margin = 2
 title_font_color = 'rgb(255,140,0)'

--- a/PACKAGE/base/EX-WORKFLOW/images/notebooks.diag
+++ b/PACKAGE/base/EX-WORKFLOW/images/notebooks.diag
@@ -1,6 +1,7 @@
    blockdiag {
     node_width = 230;
     node_height = 145;
+    span_width = 40
 
         group {
             orientation = portrait;

--- a/images/notebooks.diag
+++ b/images/notebooks.diag
@@ -1,8 +1,8 @@
-
    blockdiag {
-    node_width = 400;
-    node_height = 250;
+    node_width = 230;
+    node_height = 145;
     orientation = portrait;
+    span_width = 40
 
         group {
             shape = line;
@@ -15,9 +15,9 @@
                 group {
                     orientation = portrait;
                     color = "#ffeed9";
-                    "0. prepare_for_workflow"[label = "0. ワークフロー機能の実行準備", fontsize = 23];
+                    "0. prepare_for_workflow"[label = "0. ワークフロー機能の実行準備", fontsize = 14];
                     "base_required_every_time";
-                    "base_required_first_time";
+                    "base_required_first_time"[fontsize = 14];
                 }
             }
 
@@ -28,7 +28,7 @@
                 group {
                     orientation = portrait;
                     color = "#fcdcb1";
-                    "1. preparation_phase"[label = "1. 研究準備フェーズ", fontsize = 23];
+                    "1. preparation_phase"[label = "1. 研究準備フェーズ", fontsize = 14];
                     "base_setup_data_analysis_tools";
                     "base_work_with_GakuNinRDM";
                 }
@@ -41,7 +41,7 @@
                 group {
                     orientation = portrait;
                     color = "#ffd6a1";
-                    "2. experimental_phase"[label = "2. 実験期フェーズ", fontsize = 23];
+                    "2. experimental_phase"[label = "2. 実験期フェーズ", fontsize = 14];
                     "base_launch_an_experiment";
                     "dummy"[shape=none, width=1, height=1];
                     "base_monitor_data_size";
@@ -56,8 +56,8 @@
                 group {
                     orientation = portrait;
                     color = "#ffb95c";
-                    "3. after_experiments_phase"[label = "3 実験終了後フェーズ", fontsize = 23];
-                    "base_publish"[fontsize = 20];
+                    "3. after_experiments_phase"[label = "3 実験終了後フェーズ", fontsize = 14];
+                    "base_publish"[fontsize = 14];
                 }
             }
             group {
@@ -67,7 +67,7 @@
                 group {
                     orientation = portrait;
                     color = "#ffa329";
-                    "4. after_research"[label = "4. 研究終了後", fontsize = 23];
+                    "4. after_research"[label = "4. 研究終了後", fontsize = 14];
                     "base_finish_research";
                 }
             }


### PR DESCRIPTION
## やったこと

一度のみ実行するセクションが実行済みかどうかをワークフロー図に反映する処理を追加した。
今のところ対象は、base_required_first_time.ipynbのみ。
また、これに関連してワークフロー図のノード間の距離を縮めるなどデザインの修正をした。

## やらないこと

なし。

## できるようになること（ユーザ目線）

すでに実行したワークフロー機能が一目で分かる。

## できなくなること（ユーザ目線）

なし。

## 動作確認の内容と結果

テンプレートを修正済みのものに更新後、maDMP→base_FLOW→base_required_first_time→base_FLOWの順に実行した。
済マークが表示されることを確認した。
また、ワークフロー図更新処理を複数実行した場合にも正しく表示されることを確認した。

## その他

特になし。